### PR TITLE
Remove the SNS Topic's display name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -198,10 +198,6 @@ resource "aws_sns_topic" "ses_bounces" {
 
   kms_master_key_id = "alias/aws/sns"
 
-  display_name = coalesce(
-    var.bounce_topic_name,
-    "${local.email_domain} SES bounces"
-  )
   name = coalesce(
     var.bounce_topic_name,
     "${replace(local.email_domain, "/[^A-Za-z0-9-_]/", "-")}-ses-bounces"


### PR DESCRIPTION
[MA-1342](https://support.gtis.sil.org/issue/MA-1342)

---


### Changed (non-breaking)
- Remove the SNS Topic's display name
  * There seems to be a bug in AWS's SES Notification validation that rejects SNS Topics that have a Display Name with spaces, dots, etc. (even though SNS allows those in the display name). Removing the Display Name here, since it does not benefit us if it has to match the same naming constraints as the SNS Topic Name.