### PR TITLE
upgrade setup-terraform action

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -28,7 +28,7 @@ jobs:
 
     # Install the latest version of Terraform CLI
     - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v3
+      uses: hashicorp/setup-terraform@v4
 
     # Checks that all Terraform configuration files adhere to a canonical format
     - name: Terraform Format


### PR DESCRIPTION
[ITSE-2562 Upgrade GitHub Action steps that are using Node 20](https://support.gtis.sil.org/issue/ITSE-2562)

---

### Changed
- Update hashicorp/setup-terraform action to v4 to include support for Node 24. The first round of PRs missed this update.