### PR TITLE
Add configurable MAIL FROM subdomain SPF record

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Includes:
 * SES Domain Identity
 * DKIM records for mail domain
 * SES Domain MAIL FROM
-* SPF and MX record for MAIL FROM domain
+* SPF (with `mx` mechanism) and MX record for MAIL FROM domain
 * Optional: AWS IAM user for SMTP mailing
 * Optional: AWS IAM ECS Role
 * Optional: SPF and DMARC records for mail domain

--- a/main.tf
+++ b/main.tf
@@ -94,7 +94,7 @@ resource "cloudflare_dns_record" "from_domain_spf" {
   name    = local.mail_from_domain
   type    = "TXT"
   zone_id = data.cloudflare_zone.this.id
-  content = "\"v=spf1 include:amazonses.com -all\""
+  content = var.mail_from_spf_record_text
   tags    = var.cloudflare_tags
   comment = "SPF record for ${local.email_domain} bounce messages"
   ttl     = 1

--- a/test/main.tf
+++ b/test/main.tf
@@ -7,20 +7,18 @@ module "minimal" {
 module "all" {
   source = "../"
 
-  email_from_address        = "no_reply@example.com"
-  create_smtp_user          = true
-  smtp_user_name            = "smtp-user-example-com"
-  create_ecs_role           = true
-  ecs_role_name             = "ecs-role-example-com"
-  create_spf_record         = true
-  spf_record_text           = "v=spf1 include:amazonses.com -all"
-  mail_from_spf_record_text = "\"v=spf1 mx include:amazonses.com -all\""
-  create_dmarc_record       = true
-  dmarc_record_text         = "v=DMARC1; p=none; sp=reject"
-  mail_from_subdomain       = "bounce"
-  cloudflare_tags           = ["customer:Acme, Inc."]
-  create_bounce_topic       = true
-  bounce_topic_name         = "example-ses-bounces"
+  email_from_address  = "no_reply@example.com"
+  create_smtp_user    = true
+  smtp_user_name      = "smtp-user-example-com"
+  create_ecs_role     = true
+  ecs_role_name       = "ecs-role-example-com"
+  create_spf_record   = true
+  create_dmarc_record = true
+  dmarc_record_text   = "v=DMARC1; p=none; sp=reject"
+  mail_from_subdomain = "bounce"
+  cloudflare_tags     = ["customer:Acme, Inc."]
+  create_bounce_topic = true
+  bounce_topic_name   = "example-ses-bounces"
 }
 
 provider "aws" {

--- a/test/main.tf
+++ b/test/main.tf
@@ -7,20 +7,20 @@ module "minimal" {
 module "all" {
   source = "../"
 
-  email_from_address  = "no_reply@example.com"
-  create_smtp_user    = true
-  smtp_user_name      = "smtp-user-example-com"
-  create_ecs_role     = true
-  ecs_role_name       = "ecs-role-example-com"
-  create_spf_record           = true
-  spf_record_text             = "v=spf1 include:amazonses.com -all"
-  mail_from_spf_record_text   = "\"v=spf1 mx include:amazonses.com -all\""
-  create_dmarc_record         = true
-  dmarc_record_text   = "v=DMARC1; p=none; sp=reject"
-  mail_from_subdomain = "bounce"
-  cloudflare_tags     = ["customer:Acme, Inc."]
-  create_bounce_topic = true
-  bounce_topic_name   = "example-ses-bounces"
+  email_from_address        = "no_reply@example.com"
+  create_smtp_user          = true
+  smtp_user_name            = "smtp-user-example-com"
+  create_ecs_role           = true
+  ecs_role_name             = "ecs-role-example-com"
+  create_spf_record         = true
+  spf_record_text           = "v=spf1 include:amazonses.com -all"
+  mail_from_spf_record_text = "\"v=spf1 mx include:amazonses.com -all\""
+  create_dmarc_record       = true
+  dmarc_record_text         = "v=DMARC1; p=none; sp=reject"
+  mail_from_subdomain       = "bounce"
+  cloudflare_tags           = ["customer:Acme, Inc."]
+  create_bounce_topic       = true
+  bounce_topic_name         = "example-ses-bounces"
 }
 
 provider "aws" {

--- a/test/main.tf
+++ b/test/main.tf
@@ -12,9 +12,10 @@ module "all" {
   smtp_user_name      = "smtp-user-example-com"
   create_ecs_role     = true
   ecs_role_name       = "ecs-role-example-com"
-  create_spf_record   = true
-  spf_record_text     = "v=spf1 include:amazonses.com -all"
-  create_dmarc_record = true
+  create_spf_record           = true
+  spf_record_text             = "v=spf1 include:amazonses.com -all"
+  mail_from_spf_record_text   = "\"v=spf1 mx include:amazonses.com -all\""
+  create_dmarc_record         = true
   dmarc_record_text   = "v=DMARC1; p=none; sp=reject"
   mail_from_subdomain = "bounce"
   cloudflare_tags     = ["customer:Acme, Inc."]

--- a/variables.tf
+++ b/variables.tf
@@ -51,6 +51,12 @@ variable "spf_record_text" {
   default     = "\"v=spf1 include:amazonses.com -all\""
 }
 
+variable "mail_from_spf_record_text" {
+  description = "text string for the MAIL FROM subdomain SPF record"
+  type        = string
+  default     = "\"v=spf1 mx include:amazonses.com -all\""
+}
+
 variable "create_dmarc_record" {
   description = "enable creation of a DMARC record for the email domain"
   type        = string


### PR DESCRIPTION
### Added

- Add mail_from_spf_record_text so the MAIL FROM subdomain SPF can be customised
- Default includes mx alongside include:amazonses.com to align with the MAIL FROM MX record

[MA-1462](https://support.gtis.sil.org/issue/MA-1462) Add to bounce.mailadmin SPF DNS record to include 'mx'