### PR TITLE
add moved blocks and bump Terraform version to fix Cloudflare upgrade

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v4
       with:
-        terraform_version: '~> 1.0'
+        terraform_version: '~> 1.8.0'
 
     # Checks that all Terraform configuration files adhere to a canonical format
     - name: Terraform Format

--- a/main.tf
+++ b/main.tf
@@ -249,3 +249,28 @@ resource "aws_ses_identity_notification_topic" "bounce" {
   notification_type        = "Bounce"
   topic_arn                = one(aws_sns_topic.ses_bounces[*].arn)
 }
+
+moved {
+  from = cloudflare_record.ses_dkim
+  to   = cloudflare_dns_record.ses_dkim
+}
+
+moved {
+  from = cloudflare_record.spf
+  to   = cloudflare_dns_record.spf
+}
+
+moved {
+  from = cloudflare_record.dmarc
+  to   = cloudflare_dns_record.dmarc
+}
+
+moved {
+  from = cloudflare_record.from_domain_mx
+  to   = cloudflare_dns_record.from_domain_mx
+}
+
+moved {
+  from = cloudflare_record.from_domain_spf
+  to   = cloudflare_dns_record.from_domain_spf
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,13 +1,15 @@
 
 terraform {
-  required_version = ">= 1.0"
+  # Terraform 1.8 is required for cross-resource moving of resources, which is used to move the Cloudflare DNS records
+  # from the old resource name (cloudflare_record) to the new resource name (cloudflare_dns_record).
+  required_version = ">= 1.8"
   required_providers {
     aws = {
       version = "~> 6.0"
       source  = "hashicorp/aws"
     }
     cloudflare = {
-      version = "~> 5.0"
+      version = "5.22.0"
       source  = "cloudflare/cloudflare"
     }
   }


### PR DESCRIPTION

### Fixed
- Fix the Cloudflare provider upgrade process by adding `moved` blocks for the DNS record resources and bumping the Terraform version to 1.8 to handle the resource rename (`cloudflare_record` to `cloudflare_dns_record`).